### PR TITLE
Lead GSuite group with additional permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module organization {
 ```
 This will create a folder named `bar` within the Folder with Id `folders/12345678` GCP Org. In addition, a GSuite Group named `foo-bar` with email `foo-bar@example.com` will be created and bound to the Folder with IAM Role `roles/resourcemanager.folderViewer`.
 
+If `create_lead_gsuite_group` set to `true` then will also create a `*-lead` group which members will have additional permissions specified in `gsuite_lead_group_roles`
 
 ## Inputs
 
@@ -61,6 +62,9 @@ This will create a folder named `bar` within the Folder with Id `folders/1234567
 | gsuite\_group\_name | Name of GSuite Group. If none provided then no GSuite group will be created nor bound to the Folder. | `string` | `""` | no |
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |
 | mock\_gsuite\_group\_name | Due limitations with Terraform Count and data resource lookups we must use a mock email address instead of an empty value. | `string` | `"placeholder-123"` | no |
+| create\_lead\_gsuite\_group | If the Tribe or Clan Lead GSuite group should be created | `string` | `false` | no |
+| gsuite\_lead\_group\_members | Users and Groups to add to Lead GSuite group | the same as gsuite_group_members | `{ groups = [], users  = [] }` | no |
+| gsuite\_lead\_group\_roles | List of roles additionally granted to Lead GSuite group | `[]` | no |
 
 ## Outputs
 
@@ -69,3 +73,5 @@ This will create a folder named `bar` within the Folder with Id `folders/1234567
 | folder\_id | Folder ID of the created GCP Folder |
 | group\_email | Email address of the created GSuite Group |
 | group\_name | Name of the created GSuite Group |
+| lead\_group\_email | Email address of the created GSuite Lead Group |
+/ lead_group_name | Name of the created GSuite Lead Group |

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ If `create_lead_gsuite_group` set to `true` then will also create a `*-lead` gro
 | impersonated\_user\_email | Email account of GSuite Admin user to impersonate for creating GSuite Groups. If not provided, will default to `terraform@<var.domain>` | `string` | `""` | no |
 | mock\_gsuite\_group\_name | Due limitations with Terraform Count and data resource lookups we must use a mock email address instead of an empty value. | `string` | `"placeholder-123"` | no |
 | create\_lead\_gsuite\_group | If the Tribe or Clan Lead GSuite group should be created | `string` | `false` | no |
-| gsuite\_lead\_group\_members | Users and Groups to add to Lead GSuite group | the same as gsuite_group_members | `{ groups = [], users  = [] }` | no |
-| gsuite\_lead\_group\_roles | List of roles additionally granted to Lead GSuite group | `[]` | no |
+| gsuite\_lead\_group\_members | Users and Groups to add Lead GSuite group | the same as gsuite_group_members | `{ groups = [], users  = [] }` | no |
+| gsuite\_lead\_group\_roles | List of IAM Roles to additionally grant the Lead GSuite group | `["roles/secretmanager.admin"]` | no |
 
 ## Outputs
 
@@ -74,4 +74,4 @@ If `create_lead_gsuite_group` set to `true` then will also create a `*-lead` gro
 | group\_email | Email address of the created GSuite Group |
 | group\_name | Name of the created GSuite Group |
 | lead\_group\_email | Email address of the created GSuite Lead Group |
-/ lead_group_name | Name of the created GSuite Lead Group |
+| lead\_group\_name | Name of the created GSuite Lead Group |

--- a/main.tf
+++ b/main.tf
@@ -15,20 +15,6 @@ module group {
   members   = var.gsuite_group_members
 }
 
-module folder {
-  source = "./modules/folder"
-
-  name      = var.folder_name
-  parent_id = var.folder_parent_id
-  domain    = var.domain
-
-  folder_view_iam_role        = var.folder_view_iam_role
-  iam_roles                   = var.folder_iam_roles
-  additional_iam_member_bindings = var.folder_additional_iam_member_bindings
-  gsuite_group_email          = local.gsuite_group_email
-  mock_gsuite_group_name      = var.mock_gsuite_group_name
-}
-
 module lead_group {
   source = "./modules/group"
 
@@ -36,4 +22,20 @@ module lead_group {
   mock_name = var.mock_gsuite_group_name
   email     = local.gsuite_lead_group_email
   members   = var.gsuite_lead_group_members
+}
+
+module folder {
+  source = "./modules/folder"
+
+  name      = var.folder_name
+  parent_id = var.folder_parent_id
+  domain    = var.domain
+
+  folder_view_iam_role   = var.folder_view_iam_role
+  iam_roles              = var.folder_iam_roles
+  gsuite_group_email     = local.gsuite_group_email
+  mock_gsuite_group_name = var.mock_gsuite_group_name
+
+  gsuite_lead_group_email = local.gsuite_lead_group_email
+  gsuite_lead_group_roles = var.gsuite_lead_group_roles
 }

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,8 @@ locals {
   impersonated_user_email = coalesce(var.impersonated_user_email, format("%s@%s", "terraform", var.domain))
   gsuite_group_name       = coalesce(var.gsuite_group_name, var.mock_gsuite_group_name)
   gsuite_group_email      = format("%s@%s", local.gsuite_group_name, var.domain)
+  gsuite_lead_group_name  = var.create_lead_gsuite_group==true ? format("%s-lead", var.gsuite_group_name) : var.mock_gsuite_group_name
+  gsuite_lead_group_email = format("%s@%s", local.gsuite_lead_group_name, var.domain)
 }
 
 module group {
@@ -25,4 +27,13 @@ module folder {
   additional_iam_member_bindings = var.folder_additional_iam_member_bindings
   gsuite_group_email          = local.gsuite_group_email
   mock_gsuite_group_name      = var.mock_gsuite_group_name
+}
+
+module lead_group {
+  source = "./modules/group"
+
+  name      = local.gsuite_lead_group_name
+  mock_name = var.mock_gsuite_group_name
+  email     = local.gsuite_lead_group_email
+  members   = var.gsuite_lead_group_members
 }

--- a/modules/folder/main.tf
+++ b/modules/folder/main.tf
@@ -1,5 +1,6 @@
 locals {
   iam_roles = concat([var.folder_view_iam_role], var.iam_roles)
+  lead_iam_roles = concat([var.iam_role], var.gsuite_lead_group_roles)
 
   # For details on this solution for producing a map/object from nested loop to support for_each in resource block
   # see https://github.com/hashicorp/terraform/issues/22263#issuecomment-581205359
@@ -42,6 +43,19 @@ resource "google_folder_iam_binding" "local" {
   members = [
     "group:${var.gsuite_group_email}",
   ]
+}
+
+resource "google_folder_iam_binding" "lead" {
+  for_each = {
+    for key, value in local.lead_iam_roles :
+    key => key
+    if var.gsuite_lead_group_email != "${var.mock_gsuite_group_name}@${var.domain}"
+  }
+  folder = google_folder.local.id
+  members = [
+    "group:${var.gsuite_lead_group_email}",
+  ]
+  role = local.lead_iam_roles[each.value]
 }
 
 resource "google_folder_iam_binding" "additional" {

--- a/modules/folder/vars.tf
+++ b/modules/folder/vars.tf
@@ -37,3 +37,13 @@ variable domain {
   type        = string
   description = "Domain name of the Organization in which to create the Folder."
 }
+
+variable gsuite_lead_group_email {
+  type        = string
+  description = "Email address of Lead GSuite Group"
+}
+
+variable gsuite_lead_group_roles {
+  type        = list(string)
+  description = "List of IAM Roles to additionally grant the Lead GSuite group"
+}

--- a/modules/group/main.tf
+++ b/modules/group/main.tf
@@ -11,7 +11,7 @@ resource "gsuite_group" "local" {
 }
 
 resource "gsuite_group_members" "local_users" {
-  count = var.name != var.mock_name && (data.gsuite_group.local.name == null || data.gsuite_group.local.description == "Created by Terraform") ? 1 : 0
+  count = var.name != var.mock_name && (data.gsuite_group.local.name == null || data.gsuite_group.local.description == "Created by Terraform") && (length(var.members.groups) > 0 || length(var.members.users) > 0)? 1 : 0
   group_email = "${gsuite_group.local[0].email}"
 
   dynamic member {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,13 @@ output group_name {
   value       = module.group.name
   description = "Name of the created GSuite Group"
 }
+
+output lead_group_email {
+  value       = module.lead_group.email
+  description = "Email address of the created GSuite Lead Group"
+}
+
+output lead_group_name {
+  value       = module.lead_group.name
+  description = "Name of the created GSuite Lead Group"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -97,3 +97,11 @@ variable gsuite_lead_group_members {
   }
   description = "Users and Groups to add as GSuite Tribe or Clan Lead Members"
 }
+
+variable gsuite_lead_group_roles {
+  type = list(string)
+  default = [
+    "roles/secretmanager.admin",
+  ]
+  description = "List of IAM Roles to additionally grant the Lead GSuite group"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -70,3 +70,30 @@ variable gsuite_group_members {
   }
   description = "Users and Groups to add as GSuite Tribe or Clan Members"
 }
+
+variable create_lead_gsuite_group {
+  type        = bool
+  default     = false
+  description = "If the Tribe or Clan Lead GSuite group should be created"
+}
+
+variable gsuite_lead_group_members {
+  type = object({
+    groups = list(object(
+      {
+        email = string
+      }
+    ))
+    users = list(object(
+      {
+        name  = string
+        email = string
+      }
+    ))
+  })
+  default = {
+    groups = [],
+    users  = []
+  }
+  description = "Users and Groups to add as GSuite Tribe or Clan Lead Members"
+}


### PR DESCRIPTION
Currently it solve the allowing clan leads to write Secret Manager secrets. But I tried to create more universal way for grant additional permissions for leads and directors (roles can be different for projects)