### PR TITLE
Ability to add more than one iam_role to folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This will create a folder named `bar` within the Folder with Id `folders/1234567
 |------|-------------|------|---------|:-----:|
 | domain | Domain name of the Organization in which to create the Folder. | `string` | n/a | yes |
 | folder\_iam\_roles | List of IAM Roles to grant the Group we bind to the GCP Folder | `list(string)` | `[]` | no |
-| folder\_view\_iam\_role | Basic IAM Role to able view folders | `string` | `"roles/resourcemanager.folderViewer"` | no |
+| folder\_view\_iam\_role | Basic IAM Role to be able to view folders | `string` | `"roles/resourcemanager.folderViewer"` | no |
 | folder\_name | The name of the GCP Folder to create | `string` | n/a | yes |
 | folder\_parent\_id | The ID of the Parent Folder in which to create the new Folder. If not provided, Folder will be created at the root of the Organization. | `string` | `""` | no |
 | gsuite\_group\_members | Users and Groups to add as GSuite Tribe or Clan Members | <pre>object({<br>    groups = list(object(<br>      {<br>        email = string<br>      }<br>    ))<br>    users = list(object(<br>      {<br>        name  = string<br>        email = string<br>      }<br>    ))<br>  })<br></pre> | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This will create a folder named `bar` within the Folder with Id `folders/1234567
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | domain | Domain name of the Organization in which to create the Folder. | `string` | n/a | yes |
-| folder\_iam\_role | List of IAM Roles to grant the Group we bind to the GCP Folder | `list(string)` | `[]` | no |
+| folder\_iam\_roles | List of IAM Roles to grant the Group we bind to the GCP Folder | `list(string)` | `[]` | no |
 | folder\_view\_iam\_role | Basic IAM Role to able view folders | `string` | `"roles/resourcemanager.folderViewer"` | no |
 | folder\_name | The name of the GCP Folder to create | `string` | n/a | yes |
 | folder\_parent\_id | The ID of the Parent Folder in which to create the new Folder. If not provided, Folder will be created at the root of the Organization. | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This will create a folder named `bar` within the Folder with Id `folders/1234567
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | domain | Domain name of the Organization in which to create the Folder. | `string` | n/a | yes |
-| folder\_iam\_role | The IAM Role to grant the Group we bind to the GCP Folder | `string` | `"roles/resourcemanager.folderViewer"` | no |
+| folder\_iam\_role | List of IAM Roles to grant the Group we bind to the GCP Folder | `list(string)` | `[]` | no |
+| folder\_view\_iam\_role | Basic IAM Role to able view folders | `string` | `"roles/resourcemanager.folderViewer"` | no |
 | folder\_name | The name of the GCP Folder to create | `string` | n/a | yes |
 | folder\_parent\_id | The ID of the Parent Folder in which to create the new Folder. If not provided, Folder will be created at the root of the Organization. | `string` | `""` | no |
 | gsuite\_group\_members | Users and Groups to add as GSuite Tribe or Clan Members | <pre>object({<br>    groups = list(object(<br>      {<br>        email = string<br>      }<br>    ))<br>    users = list(object(<br>      {<br>        name  = string<br>        email = string<br>      }<br>    ))<br>  })<br></pre> | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,8 @@ module folder {
   parent_id = var.folder_parent_id
   domain    = var.domain
 
-  iam_role               = var.folder_iam_role
+  folder_view_iam_role   = var.folder_view_iam_role
+  iam_roles              = var.folder_iam_roles
   gsuite_group_email     = local.gsuite_group_email
   mock_gsuite_group_name = var.mock_gsuite_group_name
 }

--- a/modules/folder/vars.tf
+++ b/modules/folder/vars.tf
@@ -20,7 +20,7 @@ variable mock_gsuite_group_name {
 
 variable folder_view_iam_role {
   type        = string
-  description = "Basic IAM Role to able view folders"
+  description = "Basic IAM Role to be able to view folders"
 }
 
 variable iam_roles {

--- a/modules/folder/vars.tf
+++ b/modules/folder/vars.tf
@@ -18,9 +18,14 @@ variable mock_gsuite_group_name {
   description = "Due limitations with Terraform Count and data resource lookups we must use a mock email address instead of an empty value."
 }
 
-variable iam_role {
+variable folder_view_iam_role {
   type        = string
-  description = "The IAM Role to grant the Group we bind to the GCP Folder"
+  description = "Basic IAM Role to able view folders"
+}
+
+variable iam_roles {
+  type        = list(string)
+  description = "The IAM Roles to grant the Group we bind to the GCP Folder"
 }
 
 variable domain {

--- a/vars.tf
+++ b/vars.tf
@@ -12,7 +12,7 @@ variable folder_parent_id {
 variable folder_view_iam_role {
   type        = string
   default     = "roles/resourcemanager.folderViewer"
-  description = "Basic IAM Role to able view folders"
+  description = "Basic IAM Role to be able to view folders"
 }
 
 variable folder_iam_roles {

--- a/vars.tf
+++ b/vars.tf
@@ -9,9 +9,16 @@ variable folder_parent_id {
   description = "The ID of the Parent Folder in which to create the new Folder. If not provided, Folder will be created at the root of the Organization."
 }
 
-variable folder_iam_role {
+variable folder_view_iam_role {
+  type        = string
   default     = "roles/resourcemanager.folderViewer"
-  description = "The IAM Role to grant the Group we bind to the GCP Folder"
+  description = "Basic IAM Role to able view folders"
+}
+
+variable folder_iam_roles {
+  type        = list(string)
+  default     = []
+  description = "List of IAM Roles to grant the Group we bind to the GCP Folder"
 }
 
 variable impersonated_user_email {


### PR DESCRIPTION
This PR changes string variable iam_role to list variable iam_roles which contains IAM Roles to add folder additionally to `"roles/resourcemanager.folderViewer"` role.
Role `"roles/resourcemanager.folderViewer"` now  defined in variable `folder_view_iam_role`.

NOTE: Because roles become list instead of string applying this code on existing infrastructure cause recreating iam_binding resources for existing folder