### PR TITLE
Avoid numbered indexes in state file

### DIFF
--- a/modules/folder/main.tf
+++ b/modules/folder/main.tf
@@ -32,7 +32,7 @@ resource "google_folder" "local" {
 resource "google_folder_iam_binding" "local" {
   for_each = {
     for key, value in local.iam_roles :
-    key => key
+    value => key
     if var.gsuite_group_email != "${var.mock_gsuite_group_name}@${var.domain}"
   }
 


### PR DESCRIPTION
This PR make named indexes instead numbered in terraform state file, so insert new role will not cause force replacing all trailed roles in a list.

NOTE: During update to this version first run `terraform apply` may fail because trying to create existing IAM before deleting it. The second run `terraform apply` will resolve errors.